### PR TITLE
Add "verify registration" buttons + forms to the site

### DIFF
--- a/src/layouts/va-form.astro
+++ b/src/layouts/va-form.astro
@@ -1,0 +1,92 @@
+---
+import Layout from "./Layout.astro";
+import VoteAmericaAnalytics from "../components/VoteAmericaAnalytics";
+
+// define the props type
+interface Props {
+  /** Page title. */
+  title: string;
+
+  /** Action description for the generic banner. */
+  action: string;
+}
+
+const { title, action } = Astro.props;
+---
+
+<Layout title={title}>
+  {/* Add VoteAmerica+ Embed Tools To <head> section of page. */}
+  <script
+    slot="head"
+    src="https://cdn.voteamerica.com/embed/tools.js"
+    async
+    is:inline></script>
+
+  <main>
+    {/* Header for above the vote america form. */}
+    <div class="bg-murk py-6 border-b-4 border-black">
+      <div class="max-w-[664px] mx-auto">
+        <div
+          class="mx-[12px] va:mx-[4px] flex flex-row space-x-10 va:space-y-0 justify-between items-center"
+        >
+          <div class="flex flex-col">
+            <p
+              class="uppercase font-black text-[10px] va:text-[12px] leading-[10px] ml-[2px]"
+            >
+              Make&nbsp;your&nbsp;vote
+            </p>
+            <h1
+              class="font-cabinet font-extrabold pt-2 text-[32px] va:text-[38px] leading-[30px] va:leading-[35px] tracking-tight cursor-pointer transition-colors duration-200"
+              onclick="window.history.back()"
+            >
+              Count<br /><span class="pl-[1px]">More</span>
+            </h1>
+          </div>
+          <p
+            class="font-satoshi font-medium text-[15px] leading-[20px] va:text-[16px] va:leading-[23px]"
+          >
+            <span id="battleground-span" class="hidden"></span>{action} below with
+            our trusted partner VoteAmerica.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    {/* Embed the primary voteamerica area */}
+    <div class="bg-white pt-10 pb-20">
+      <slot />
+    </div>
+  </main>
+
+  {/* Implement Vote America analytics watching. */}
+  <VoteAmericaAnalytics client:only="react" />
+</Layout>
+
+<script>
+  // CONSIDER: Move this to a framework component if it gets any more complex.
+
+  // @ts-nocheck
+  function showBattlegroundMessage() {
+    const url = new URL(window.location.href);
+    const params = new URLSearchParams(url.search);
+    // see if there's a chosen=Y param
+    const chosen = params.get("chosen");
+    if (chosen) {
+      const battlegroundSpan = document.getElementById("battleground-span");
+      if (battlegroundSpan) {
+        battlegroundSpan.innerText = `Your vote counts more in ${chosen}. `;
+        battlegroundSpan.classList.remove("hidden");
+      }
+    }
+  }
+
+  function ready(fn) {
+    if (document.readyState != "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  ready(showBattlegroundMessage);
+</script>

--- a/src/layouts/va-form.astro
+++ b/src/layouts/va-form.astro
@@ -78,6 +78,8 @@ const { title, action } = Astro.props;
         battlegroundSpan.classList.remove("hidden");
       }
     }
+
+    console.log("GOT DONE WITH THIS", params);
   }
 
   function ready(fn) {

--- a/src/pages/va-register.astro
+++ b/src/pages/va-register.astro
@@ -1,82 +1,12 @@
 ---
-import Layout from "../layouts/Layout.astro";
-import VoteAmericaAnalytics from "../components/VoteAmericaAnalytics";
+import VAForm from "../layouts/va-form.astro";
 ---
 
-<Layout title="Count More: Register To Vote">
-  {/* Add VoteAmerica+ Embed Tools To <head> section of page. */}
-  <script slot="head" src="https://cdn.voteamerica.com/embed/tools.js" async
-  ></script>
-
-  <main>
-    <div class="bg-murk py-6 border-b-4 border-black">
-      <div class="max-w-[664px] mx-auto">
-        <div
-          class="mx-[12px] va:mx-[4px] flex flex-row space-x-10 va:space-y-0 justify-between items-center"
-        >
-          <div class="flex flex-col">
-            <p
-              class="uppercase font-black text-[10px] va:text-[12px] leading-[10px] ml-[2px]"
-            >
-              Make&nbsp;your&nbsp;vote
-            </p>
-            <h1
-              class="font-cabinet font-extrabold pt-2 text-[32px] va:text-[38px] leading-[30px] va:leading-[35px] tracking-tight cursor-pointer transition-colors duration-200"
-              onclick="window.history.back()"
-            >
-              Count<br /><span class="pl-[1px]">More</span>
-            </h1>
-          </div>
-          <p
-            class="font-satoshi font-medium text-[15px] leading-[20px] va:text-[16px] va:leading-[23px]"
-          >
-            <span id="battleground-span" class="hidden"></span>Register to vote
-            below with our trusted partner VoteAmerica.
-          </p>
-        </div>
-      </div>
-    </div>
-
-    {/* Embed the primary voteamerica area */}
-    <div class="bg-white pt-10 pb-20">
-      <div
-        class="voteamerica-embed"
-        data-subscriber="countmore"
-        data-tool="register"
-      >
-      </div>
-    </div>
-  </main>
-
-  {/* Implement Vote America analytics watching. */}
-  <VoteAmericaAnalytics client:only="react" />
-</Layout>
-
-<script>
-  // CONSIDER: Move this to a framework component if it gets any more complex.
-
-  // @ts-nocheck
-  function showBattlegroundMessage() {
-    const url = new URL(window.location.href);
-    const params = new URLSearchParams(url.search);
-    // see if there's a chosen=Y param
-    const chosen = params.get("chosen");
-    if (chosen) {
-      const battlegroundSpan = document.getElementById("battleground-span");
-      if (battlegroundSpan) {
-        battlegroundSpan.innerText = `Your vote counts more in ${chosen}. `;
-        battlegroundSpan.classList.remove("hidden");
-      }
-    }
-  }
-
-  function ready(fn) {
-    if (document.readyState != "loading") {
-      fn();
-    } else {
-      document.addEventListener("DOMContentLoaded", fn);
-    }
-  }
-
-  ready(showBattlegroundMessage);
-</script>
+<VAForm title="Count More: Register To Vote" action="Register to vote">
+  <div
+    class="voteamerica-embed"
+    data-subscriber="countmore"
+    data-tool="register"
+  >
+  </div>
+</VAForm>

--- a/src/pages/va-verify.astro
+++ b/src/pages/va-verify.astro
@@ -1,0 +1,11 @@
+---
+import VAForm from "../layouts/va-form.astro";
+---
+
+<VAForm
+  title="Count More: Register To Vote"
+  action="Check your registration status"
+>
+  <div class="voteamerica-embed" data-subscriber="countmore" data-tool="verify">
+  </div>
+</VAForm>

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -96,8 +96,34 @@ export const fireClickRegisterEvent = (event: ClickRegisterEvent) => {
   });
 };
 
+/**
+ * The "click to verify" event type. This event is fired when a user clicks a
+ * 'verify registration' button.
+ */
+export interface ClickVerifyEvent {
+  /** The state the user clicked to verify in. */
+  state: State;
+
+  /** Where we plan to take them next. */
+  handler: RegistrationHandler;
+}
+
+/** Fire the click to verify event. */
+export const fireClickVerifyEvent = (event: ClickVerifyEvent) => {
+  const battleground = isBattleground(event.state);
+  fireGoogle("event", "click_verify", {
+    event_category: "engagement",
+    battleground,
+    ...event,
+  });
+  fireMetaCustom("ClickVerify", {
+    battleground,
+    ...event,
+  });
+};
+
 /** Generic information about the registering user. */
-export interface RegisterUser {
+export interface VoterUser {
   /** The user's state of registration. */
   state: State;
 
@@ -109,7 +135,7 @@ export interface RegisterUser {
  * The "start registration form" event type. This event is fired when a user
  * starts filling out a registration form -- any form.
  */
-export interface RegisterStartEvent extends RegisterUser {
+export interface RegisterStartEvent extends VoterUser {
   handler: RegistrationHandler;
 }
 
@@ -127,6 +153,28 @@ export const fireRegisterStartEvent = (event: RegisterStartEvent) => {
   });
 };
 
+/**
+ * The "start verify form" event type. This event is fired when a user
+ * starts filling out a verify form -- any form.
+ */
+export interface VerifyStartEvent extends VoterUser {
+  handler: RegistrationHandler;
+}
+
+/** Fire the start verify form event. */
+export const fireVerifyStartEvent = (event: VerifyStartEvent) => {
+  const battleground = isBattleground(event.state);
+  fireGoogle("event", "verify_start", {
+    event_category: "engagement",
+    battleground,
+    ...event,
+  });
+  fireMetaCustom("VerifyStart", {
+    battleground,
+    ...event,
+  });
+};
+
 /** The three common outcomes in registration. */
 export type RegisterFinishMethod = "online" | "paper" | "ineligible";
 
@@ -134,7 +182,7 @@ export type RegisterFinishMethod = "online" | "paper" | "ineligible";
  * The "finish registration form" event type. This event is fired when a user
  * completes a registration form -- any form.
  */
-export interface RegisterFinishEvent extends RegisterUser {
+export interface RegisterFinishEvent extends VoterUser {
   handler: RegistrationHandler;
   method: RegisterFinishMethod;
   url?: string;
@@ -154,6 +202,28 @@ export const fireRegisterFinishEvent = (event: RegisterFinishEvent) => {
   });
 };
 
+/**
+ * The "finish verify form" event type. This event is fired when a user
+ * completes a verify form -- any form.
+ */
+export interface VerifyFinishEvent extends VoterUser {
+  handler: RegistrationHandler;
+}
+
+/** Fire the finish verify form event. */
+export const fireVerifyFinishEvent = (event: VerifyFinishEvent) => {
+  const battleground = isBattleground(event.state);
+  fireGoogle("event", "verify_finish", {
+    event_category: "engagement",
+    battleground,
+    ...event,
+  });
+  fireMetaCustom("VerifyFinish", {
+    battleground,
+    ...event,
+  });
+};
+
 /** The two common follow-up actions. */
 export type RegisterFollowUpMethod = "confirm-online" | "request-paper";
 
@@ -161,7 +231,7 @@ export type RegisterFollowUpMethod = "confirm-online" | "request-paper";
  * The "follow up registration" event type. This event is fired when a user
  * takes some kind of follow up action.
  */
-export interface RegisterFollowUpEvent extends RegisterUser {
+export interface RegisterFollowUpEvent extends VoterUser {
   handler: RegistrationHandler;
   method: RegisterFollowUpMethod;
   url?: string;


### PR DESCRIPTION
We now _always_ display two buttons, one for "Verify registration" and one for "Register to vote". In cases where either state will do, we just have generic buttons; in cases where we're explicitly suggesting a state, the buttons name the state by abbreviation.

This adds two new events that go to both Facebook and Google: 

- `VerifyStart` and `VerifyFinish`. `VerifyStart` happens after the user submits the initial intake form. `VerifyFinish` generally speaking happens _right_ after (see https://docs.voteamerica.com/software/events/#action-finish-event-4)

