### PR TITLE
Small tweaks

### DIFF
--- a/src/components/More.tsx
+++ b/src/components/More.tsx
@@ -336,21 +336,6 @@ const SelectionHeadline: React.FC<{ result: StateSelectionResult }> = ({
   );
 };
 
-/** Renders a detailed description of the power ranking. */
-const PowerRankingDetails: React.FC<{ result: StateSelectionResult }> = ({
-  result,
-}) => {
-  if (isBattleground(selectedState(result))) {
-    return (
-      <>
-        is a “swing state” where a small number of votes can swing the election
-      </>
-    );
-  } else {
-    return <>is a “leaning state” where your vote can have more impact</>;
-  }
-};
-
 /** Renders the detail text for a two-state selection. */
 const SelectionDetails: React.FC<{ result: StateSelectionResult }> = ({
   result,
@@ -365,8 +350,8 @@ const SelectionDetails: React.FC<{ result: StateSelectionResult }> = ({
         <>
           In this presidential election, your vote has more impact in{" "}
           <span className="text-point">{selectedStateName(result)}</span> than
-          in {otherStateName(result)}. {selectedStateName(result)}{" "}
-          {<PowerRankingDetails result={result} />}.
+          in {otherStateName(result)}. {selectedStateName(result)} is a “swing
+          state” where a small number of votes can swing the election.
         </>
       );
       break;
@@ -376,12 +361,21 @@ const SelectionDetails: React.FC<{ result: StateSelectionResult }> = ({
       break;
 
     case "same":
-      message = (
-        <>
-          That makes things simple: vote in{" "}
-          <span className="text-point">{homeStateName(result)}</span>.
-        </>
-      );
+      if (isBattleground(result.homeState)) {
+        message = (
+          <>
+            Your vote counts more in{" "}
+            <span className="text-point">{homeStateName(result)}</span>.
+          </>
+        );
+      } else {
+        message = (
+          <>
+            That makes things simple: vote in{" "}
+            <span className="text-point">{homeStateName(result)}</span>.
+          </>
+        );
+      }
       break;
 
     default:
@@ -396,7 +390,7 @@ const SelectionDetails: React.FC<{ result: StateSelectionResult }> = ({
         In 2020,{" "}
         <span className="font-black">{winner(election, CANDIDATES_2020)}</span>{" "}
         won {selectedStateName(result)} by a razor-thin margin of{" "}
-        {formatMargin(election)} votes (&lt;1%).
+        {formatMargin(election)} votes.
       </>
     );
   } else if (mp < 0.025) {
@@ -405,7 +399,7 @@ const SelectionDetails: React.FC<{ result: StateSelectionResult }> = ({
         In 2020,{" "}
         <span className="font-black">{winner(election, CANDIDATES_2020)}</span>{" "}
         won {selectedStateName(result)} by a slim margin of{" "}
-        {formatMargin(election)} votes (&lt;2.5%).
+        {formatMargin(election)} votes.
       </>
     );
   }
@@ -439,12 +433,14 @@ const DescribeSelection: React.FC<{
           state={homeState}
           handler={handler}
           behavior="verify"
+          chosen={isBattleground(homeState)}
         />
         <RegisterToVoteButton
           state={homeState}
           handler={handler}
           behavior="register"
           className="ml-4"
+          chosen={isBattleground(homeState)}
         />
       </>
     );

--- a/src/components/More.tsx
+++ b/src/components/More.tsx
@@ -218,9 +218,6 @@ interface RegisterToVoteButtonProps {
   /** If true, this was a preferred state. */
   chosen?: boolean;
 
-  /** If true, hide the state name in the button. */
-  hideState?: boolean;
-
   className?: string;
 }
 
@@ -230,7 +227,6 @@ const RegisterToVoteButton: React.FC<RegisterToVoteButtonProps> = ({
   handler,
   behavior,
   chosen,
-  hideState,
   className,
 }) => {
   const handleRegistrationClick = useCallback(
@@ -279,16 +275,7 @@ const RegisterToVoteButton: React.FC<RegisterToVoteButtonProps> = ({
       onClick={(e) => handleRegistrationClick(e, state, chosen)}
       aria-label={`Follow this link to register to vote in ${STATE_NAMES[state]}`}
     >
-      {behavior === "register" ? "Register to vote" : "Verify registration"}
-      {!hideState && (
-        <>
-          {" "}
-          in{" "}
-          <span className="font-cabinet inline-block w-8 min-w-8 max-w-8">
-            {state.toUpperCase()}
-          </span>
-        </>
-      )}
+      {behavior === "register" ? "Register to vote" : "Check your registration"}
     </a>
   );
 };
@@ -444,27 +431,8 @@ const DescribeSelection: React.FC<{
   const { selection, homeState } = result;
 
   let buttons;
-  if (selection === "toss-up") {
+  if (selection === "toss-up" || selection === "same") {
     // Show one generic register button + one generic verify button
-    buttons = (
-      <>
-        <RegisterToVoteButton
-          hideState
-          state={homeState}
-          handler={handler}
-          behavior="verify"
-        />
-        <RegisterToVoteButton
-          hideState
-          state={homeState}
-          handler={handler}
-          behavior="register"
-          className="ml-4"
-        />
-      </>
-    );
-  } else if (selection === "same") {
-    // Show one state-specific register button and one state-specific verify
     buttons = (
       <>
         <RegisterToVoteButton

--- a/src/election/powerRankings.ts
+++ b/src/election/powerRankings.ts
@@ -9,12 +9,12 @@ const POWER_RANKINGS: Record<string, number> = {
   PA: 40,
   WI: 40,
   NC: 20,
-  FL: 10,
-  ME: 10,
-  MN: 10,
-  NH: 10,
-  TX: 10,
-  NE: 10,
+  // FL: 10,
+  // ME: 10,
+  // MN: 10,
+  // NH: 10,
+  // TX: 10,
+  // NE: 10,
   // everyone else gets 0
   // See https://docs.google.com/spreadsheets/d/1ST7LSXFAVyXs2Kbqs7MCrVyVArXOwd0VvKVL5e_14oc/edit#gid=1670074123
 };
@@ -23,10 +23,7 @@ const POWER_RANKINGS: Record<string, number> = {
 export const powerRanking = (st: State): number => POWER_RANKINGS[st] || 0;
 
 /** Return true if the state is one of the key battleground states. */
-export const isBattleground = (st: State): boolean => powerRanking(st) === 40;
-
-/** Return true if the state has any power ranking. */
-export const hasPowerRanking = (st: State): boolean => powerRanking(st) !== 0;
+export const isBattleground = (st: State): boolean => powerRanking(st) > 0;
 
 /** The possible selection outcomes. */
 export type StateSelection = "home" | "school" | "toss-up" | "same";


### PR DESCRIPTION
Per Matt's email:

- Change button text from "Verify registration in AZ" to "Check your registration"
Note: This matches the form you land on and might help conversion.
- Change "Register to vote in AZ" to "Register to vote"  (Note: I worry the acronym is a little confusing.)

In the case where both selections are a battleground state (e.g. AZ and AZ):
- Change title to "Your vote counts more in Arizona"
- Remove "That makes tings simple: vote in Arizona."
- In all cases, remove the (<1%) percentages since this the symbols and percentages may confuse people. 
- Let's remove the [Likely D and ](https://www.cookpolitical.com/ratings/presidential-race-ratings)[Likely](https://www.cookpolitical.com/ratings/presidential-race-ratings)[ R states](https://www.cookpolitical.com/ratings/presidential-race-ratings) from our list of swing states. This addresses your Texas feedback.